### PR TITLE
:bug: protocolVersion must be of type string

### DIFF
--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -184,7 +184,7 @@ abstract class AbstractRequest extends BaseAbstractRequest
                 'Content-Type' => 'application/json'
             ],
             json_encode($this->insertApiKeyToData($data)),
-            $this->getOptions()
+            is_array($this->getOptions()) && empty($this->getOptions()) ? '' : $this->getOptions()
         );
 
         $payload =  json_decode($httpRequest->getBody()->getContents(), true);


### PR DESCRIPTION
GuzzleHttp\Psr7\Request::__construct(): Argument `#5` ($version) must be of type string

$this->getOptions() can return a empty array